### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+See [our code of conduct for all FINN's repos](https://finn-no.github.io/code-of-conduct.html).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-finn-no.github.com
-==================
+# finn-no.github.com
+
+Maintainers:
+
+- @nicolaihoge (primary maintainer)
+- @simenb
+- @tfheen
+- @theneva
+- @3lvis
+
+## Description
+
+Information on FINN's open source projects in website form.
+
+Read more: https://finn-no.github.io
+
+## Code of conduct
+
+See [our code of conduct for all FINN's repos](https://finn-no.github.io/code-of-conduct).
+
+## License
+
+See [LICENSE](./LICENSE).

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Code of conduct</title>
+</head>
+<body>
+   This code of conduct applies to all FINN.no's projects.
+
+   <!-- TODO -->
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -61,8 +61,11 @@
             requests or comments on the projects we have made available!
         </div>
         <div class="panel panel--info">
-            In the spirit of Open Source, we have also made our <a href="oss-policy.html">Open
+            In the spirit of Open Source, we have also made our <a href="/oss-policy.html">Open
             Source Policy</a> available online.
+        </div>
+        <div class="panel panel--info">
+            A common code of conduct for all of our projects is available <a href="/code-of-conduct.html">here</a>.
         </div>
         <div class="u-t2">
             Featured projects


### PR DESCRIPTION
This should actually include a code of conduct instead of just being a todo.

The intention is to:

- Have a short code of conduct that can apply to all FINN's projects
- Link to this code of conduct from `CODE_OF_CONDUCT.md` in all repos relating to FINN's projects

This lets us automatically verify that all projects _have_ a code of conduct that points to this file.

The new panel looks like this:

![image](https://user-images.githubusercontent.com/1404650/41413409-4f920e6e-6fe3-11e8-9a61-c1d84afb9117.png)
